### PR TITLE
Declare which directories are OBS packages

### DIFF
--- a/_manifest
+++ b/_manifest
@@ -1,0 +1,10 @@
+# Which top level directories OBS should treat as packages.
+#
+# home:cbcoutinho is sourced from this repository via project level scmsync,
+# and by default the scm bridge turns *every* top level directory into a
+# package -- which caught tools/ and would catch any future directory that is
+# not a package. Listing them explicitly keeps that from happening.
+#
+# Add an entry here when adding a package directory.
+packages:
+  - process-exporter

--- a/tools/obs-refresh
+++ b/tools/obs-refresh
@@ -12,6 +12,13 @@ is for: it runs every non-buildtime service a package declares, which is what
 `osc service manualrun` would do. osc is not usable here because it insists on
 either an osc checkout or git-obs metadata, and this repository is neither.
 
+Note that the vendor tarball is only reproducible for a given Go toolchain:
+`go mod vendor` output shifts between Go releases, so running this locally on
+a different Go than CI rewrites vendor.tar.* even when the version has not
+moved. Both trees build, it is churn rather than breakage, but it means the
+CI run is the authoritative one -- match its Go version (see
+.github/workflows/obs-refresh.yml) if you intend to commit the result.
+
 Usage:
     tools/obs-refresh process-exporter [...]
     tools/obs-refresh --changelog process-exporter


### PR DESCRIPTION
`home:cbcoutinho` is now sourced from `master` — the scmsync URL is plain `https://github.com/cbcoutinho/home-cbcoutinho.git#master`, with both the branch pin and the `onlybuild=` guard dropped. That is OBS project meta rather than anything in this repository, so it is not part of this diff; it is already applied.

Flipping it surfaced one thing that *is* a repository concern.

## tools/ became an OBS package

Project level scmsync turns **every** top level directory into a package, so `osc ls home:cbcoutinho` now returns:

```
process-exporter
tools
```

`tools` has no spec, so it does not build — it is clutter rather than breakage — but the same would happen to any future directory that is not a package. A `_manifest` lists the package directories explicitly, which is the scm bridge's documented mechanism for exactly this. Adding a package now means adding an entry there too.

## Vendor tarball reproducibility

Worth recording, since it contradicts something I claimed earlier. On #4 the refresh workflow committed a changed `vendor.tar.zst` (1517055 → 1501638 bytes) even though the version had not moved. `go mod vendor` output shifts between Go releases, and CI runs `go1.24` while my local toolchain is newer — so "byte-for-byte reproducible" holds only for a fixed Go version, not across machines.

Both vendor trees build correctly, so this is churn rather than a correctness problem, but it means the CI run is the authoritative one. Noted in `tools/obs-refresh` so the next person does not chase it.

## After this merges

Ready for a Renovate run via Argo. The expected path: Renovate bumps `_service` to v0.8.7 → `obs-refresh.yml` regenerates the artifacts and pushes them onto the branch → OBS builds the PR → merge → `home:cbcoutinho` rebuilds at 0.8.7.

---

_This PR was generated with the help of AI, and reviewed by a Human_