### PR TITLE
Re-sync OBS on push to master

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,13 +1,27 @@
 # OBS SCM/CI workflow integration.
 #
-# home:cbcoutinho is sourced from this repository via project level scmsync,
-# so pushes to master are picked up by OBS on their own. That makes the old
-# trigger_services and rebuild_package steps redundant: there are no server
-# side source services to run any more (the sources come from git), and the
-# sync already schedules a rebuild.
+# home:cbcoutinho is sourced from this repository via project level scmsync.
+# That does NOT mean OBS notices pushes by itself: the webhook does deliver
+# push events, but unless a workflow acts on one, nothing re-runs the scm
+# bridge and the project silently keeps building an old commit.
+# trigger_services is the step that re-syncs an scmsync package, so master
+# needs a job of its own.
 #
-# What is still worth automating is building a pull request before it lands,
-# which happens in a scratch project branched off home:cbcoutinho.
+# Note that trigger_services names a single package, so a new package needs
+# an entry here as well as in _manifest.
+sync_master:
+  steps:
+    - trigger_services:
+        project: home:cbcoutinho
+        package: process-exporter
+  filters:
+    event: push
+    branches:
+      only:
+        - master
+
+# Pull requests are built in a scratch project branched off home:cbcoutinho,
+# so a bump is verified against every configured repository before it lands.
 build_pull_request:
   steps:
     - branch_package:


### PR DESCRIPTION
`home:cbcoutinho` has been building a stale commit since the scmsync flip, and this is why.

## What is broken

OBS is synced to `7705950`, while master is at `60fb69e` — two merges behind:

```
$ osc api /source/home:cbcoutinho/process-exporter/_scmsync.obsinfo | grep commit
commit: 77059507b36bd6822c306d21f7f06eedc5eff33e
```

Consequences, all of which looked like separate puzzles until now:

- **0.8.7 never published.** Both repositories still ship 0.8.5, despite #7 merging green.
- **`_manifest` never took effect**, so `tools` is still a package. It was never a pruning problem — the manifest simply never reached OBS.

## Why

scmsync does not poll. The GitHub webhook *does* deliver push events — it is configured for both `pull_request` and `push`:

```
url:    https://build.opensuse.org/trigger/workflow?id=9184
events: ["pull_request", "push"]
```

— but this file only filtered on `pull_request`, so no step ever ran for a push, and nothing re-ran the scm bridge. `trigger_services` is the step that re-syncs an scmsync package.

This was my mistake. When retargeting this file from duckdb I dropped its push-to-master job, on the reasoning that "scmsync picks up pushes on its own". It does not, and the failure is silent — the project keeps building happily, just from an old commit.

## The fix

A `sync_master` job running `trigger_services` on push to master. Merging this PR is itself the push that should prove it: OBS reads `.obs/workflows.yml` from the pushed commit, so the new job takes effect immediately and should sync master, publish 0.8.7, and finally apply `_manifest`.

Worth noting `trigger_services` names a single package, so a new package needs an entry here as well as in `_manifest`. Both are now per-package touchpoints.

---

_This PR was generated with the help of AI, and reviewed by a Human_